### PR TITLE
Extended grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Constellation manages 2D point grids and pathfinding. The library is designed to
 
 - Point and cell grid management.
 - Point pathfinding with [A-star](http://en.wikipedia.org/wiki/A*_search_algorithm "A-star").
-- Cell hit tests with [ray casting](http://en.wikipedia.org/wiki/Point_in_polygon "Ray casting").
+- Cell hit tests with [winding number](http://en.wikipedia.org/wiki/Point_in_polygon "Point in polygon").
 - Snapping points to line segments.
 
 See the [grid builder](http://gmac.github.io/constellation-js "constellation-js") demo for an interactive trial.

--- a/README.md
+++ b/README.md
@@ -246,9 +246,9 @@ import { intersect } from 'constellation';
 const x = intersect(new Point(0, 0), new Point(100, 100), new Point(100, 0), new Point(0, 100));
 ```
 
-**ccw(pointA, pointB, pointC, exclusive?)**
+**ccw(pointA, pointB, pointC)**
 
-Tests for counter-clockwise winding among three `Point` objects. Returns true if the three points trend in a counter-clockwise arc. Useful for testing line intersections. Passing `true` for the optional `exclusive` param will pass balanced arcs.
+Tests for counter-clockwise winding among three `Point` objects. Returns true if the three points trend in a counter-clockwise arc. Useful for testing line intersections.
 
 **intersect(pointA, pointB, pointC, pointD)**
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,23 @@ Builds a Rect primitive with the following properties:
 
 Returns `true` if the point falls within the rectangle bounds.
 
+### Constellation.ExtendedGrid
+
+```js
+import { Grid, ExtendedGrid } from 'constellation';
+const grid = new Grid(data);
+const exgrid = new ExtendedGrid(grid);
+const path = exgrid.route(new Point(10, 10), new Point(100, 100));
+```
+
+**exgrid = new ExtendedGrid(grid)**
+
+Builds a new `ExtendedGrid` instance that wraps a basic `Grid`. An extended grid allows arbitrary points outside of the base grid to be routed between using the geometry of the base grid.
+
+**exgrid.route(a, b, confineToGrid?)**
+
+Receives basic points A and B, and builds a path of points between them that follows the constraints of the base grid geometry. Start point A is always connected into the grid at the nearest valid position. End point B will be constrained to fall within grid geometry unless `confineToGrid` is specified as false. In either scenario, A and B will connect directly if their constrained positions fall within a common cell or along a common line segment. Otherwise, they will attach to their nearest geometry features and routing follows the grid to navigate between them. Returns an array of Point objects definiting the route.
+
 ### Constellation.Grid
 
 ```js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "constellation",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A grid geometry toolkit for controlling 2D sprite motion.",
   "homepage": "http://gmac.github.io/constellation-js",
   "url": "http://gmac.github.io/constellation-js",

--- a/src/extendedGrid.ts
+++ b/src/extendedGrid.ts
@@ -1,0 +1,69 @@
+import { Grid } from './grid';
+import { Cell } from './gridCell';
+import { Point } from './point';
+
+export class ExtendedGrid {
+  constructor(grid) {
+    this.grid = grid;
+  }
+
+  // Creates a path between two external (non-grid) points, using the grid to navigate between them.
+  // Start and goal points will be integrated as best as possible into the grid, then route between.
+  // @param a  Starting Point object to path from.
+  // @param b  Goal Point object to bridge to.
+  // @param confineToGrid  Specify TRUE to lock final route point to within the grid.
+  // @return  an array of Point objects specifying a path to follow.
+  route(a: Point, b: Point, confineToGrid: boolean = true): Array<Point> {
+
+    // 1) Connect points through common polygon (todo: region).
+    // 3) Snap points to grid, connect anchors to segment and related polys.
+    // 4) Direct connect points on common line segment.
+    // 5) Direct connect points in common polygon.
+
+    // Connect points through a common polygon:
+    // Get polygon intersections for each point.
+    const acells = this.grid.cellsContainingPoint(a);
+    const bcells = this.grid.cellsContainingPoint(b);
+
+    // Test if points can be bridged through the polygon grid:
+    // If so, a direction connection can be made.
+    // @todo – needs a polygon union with edge intersections
+    if (acells.find(cell => bcells.includes(cell))) {
+      return [a, b];
+    }
+
+    // Connect temporary anchors to the node grid via polygons:
+    const anchorA = createBridgeAnchor(this.grid, a, acells);
+    const anchorB = createBridgeAnchor(this.grid, b, bcells);
+  }
+}
+
+function createBridgeAnchor(grid: Grid, pt: Point, cells: Array<Cell>) {
+  const anchor = grid.addNode(pt.x, pt.y, {});
+
+  // Attach to grid if there are no polygons to hook into:
+  // this may generate some new polygons for the point.
+  if (!cells.length) {
+    var snap = grid.snapPointToGrid(pt);
+
+    if (snap.p) {
+      anchor.x = snap.p.x;
+      anchor.y = snap.p.y;
+
+      if (snap.a && snap.b) {
+        grid.joinNodes(anchor.id, snap.a.id);
+        grid.joinNodes(anchor.id, snap.b.id);
+        cells = grid.cellsWithEdge(snap.a, snap.b);
+      }
+    }
+  }
+
+  // Attach node to related polygon geometry:
+  if (cells.length) {
+    cells.forEach(cell => {
+      cell.rels.forEach(rel => grid.joinNodes(anchor.id, rel));
+    });
+  }
+
+  return anchor;
+}

--- a/src/extendedGrid.ts
+++ b/src/extendedGrid.ts
@@ -36,19 +36,19 @@ export class ExtendedGrid {
     }
 
     // Connect temporary anchors to the node grid via polygons:
-    const anchorA = this.createBridgeAnchor(a, cellsA);
-    const anchorB = this.createBridgeAnchor(b, cellsB);
+    const anchorA = this.addRouteAnchor(a, cellsA);
+    const anchorB = this.addRouteAnchor(b, cellsB);
     const path = this.grid.findPath({ start: anchorA.id, goal: anchorB.id });
     this.grid.removeNodes([anchorA.id, anchorB.id]);
 
     if (path) {
       const points: Array<Point> = path.nodes.map(n => new Point(n.x, n.y));
 
-      if (Point.distance(a, anchorA) > 1) {
+      if (Point.distance(a, anchorA) > 0) {
         points.unshift(a);
       }
 
-      if (!confineToGrid && Point.distance(b, anchorB) > 1) {
+      if (!confineToGrid && Point.distance(b, anchorB) > 0) {
         points.push(b);
       }
 
@@ -58,7 +58,7 @@ export class ExtendedGrid {
     return [];
   }
 
-  createBridgeAnchor(pt: Point, cells: Array<Cell>): Node {
+  addRouteAnchor(pt: Point, cells: Array<Cell> = []): Node {
     const anchor: Node = this.grid.addNode(pt.x, pt.y, {});
 
     // Attach to grid if there are no polygons to hook into:
@@ -75,12 +75,10 @@ export class ExtendedGrid {
       }
     }
 
-    // Attach node to related polygon geometry:
-    if (cells.length) {
-      cells.forEach(cell => {
-        cell.rels.forEach(rel => this.grid.joinNodes([anchor.id, rel]));
-      });
-    }
+    // Attach node to related cell geometry:
+    cells.forEach(cell => {
+      cell.rels.forEach(rel => this.grid.joinNodes([anchor.id, rel]));
+    });
 
     return anchor;
   }

--- a/src/grid.ts
+++ b/src/grid.ts
@@ -11,6 +11,7 @@ import {
 import {
   uuidv4,
   compositeId,
+  cross,
   snapPointToLineSegment,
   boundingRectForPoints,
   nearestPointToPoint,
@@ -181,6 +182,13 @@ export class Grid {
       }
 
       if (this.joinNodes(rels)) {
+        const [a, b, c] = rels;
+
+        // wind references counter-clockwise
+        if (cross(this.getNode(a), this.getNode(b), this.getNode(c)) > 0) {
+          rels = rels.reverse();
+        }
+
         const cell = new Cell(data?.id ?? uuidv4(), rels, data);
         this.cells[cell.id] = cell;
         return cell;

--- a/src/grid.ts
+++ b/src/grid.ts
@@ -233,7 +233,7 @@ export class Grid {
     start,
     goal,
     costForSegment = Point.distance,
-    costEstimateToGoal = Point.distance,
+    costEstimateToGoal = Point.distance2,
     bestCandidatePath = (a, _b) => a,
   }: {
     start: string,

--- a/src/grid.ts
+++ b/src/grid.ts
@@ -10,15 +10,12 @@ import {
 } from './types';
 import {
   uuidv4,
+  compositeId,
   snapPointToLineSegment,
   boundingRectForPoints,
   nearestPointToPoint,
   hitTestPointRing,
 } from './utils';
-
-function isSameLineSegment(a: Node, b: Node, c: Node, d: Node): boolean {
-  return (a.id === c.id && b.id === d.id) || (a.id === d.id && b.id === c.id);
-}
 
 export class Grid {
   private nodes: Record<string, Node> = Object.create(null);
@@ -86,9 +83,9 @@ export class Grid {
       // Loop through selection group of nodes...
       ids.forEach(id => {
         const node = this.getNode(id) as Node;
-        ids.forEach(refId => {
-          if (id !== refId) {
-            node.to[refId] = true;
+        ids.forEach(rel => {
+          if (id !== rel) {
+            node.to[rel] = true;
             changed = true;
           }
         });
@@ -107,18 +104,25 @@ export class Grid {
     }
 
     let changed = false;
+    const removedEdges: Record<string, boolean> = Object.create(null);
 
     // Decouple group node references.
     ids.forEach(id => {
       const node = this.getNode(id);
       if (node) {
-        ids.forEach(refId => {
-          if (node.to[refId]) {
-            delete node.to[refId];
+        ids.forEach(rel => {
+          if (node.to[rel]) {
+            removedEdges[compositeId([id, rel])] = true;
+            delete node.to[rel];
             changed = true;
           }
         });
       }
+    });
+
+    Object.keys(removedEdges).forEach(edge => {
+      const cells = Object.values(this.cells).filter(cell => !!cell.edges[edge]);
+      this.removeCells(cells.map(c => c.id));
     });
 
     return changed;
@@ -169,16 +173,18 @@ export class Grid {
 
   // Adds a polygon to the grid, formed by a collection of node ids.
   addCell(rels: Array<string>, data?: Record<any, any>): Cell | null {
-    if (rels.length >= 3 && this.hasNodes(rels)) {
-      const key = rels.slice().sort().join('/');
-      const existing = Object.values(this.cells).find(c => c.rels.slice().sort().join('/') === key);
+    if (rels.length === 3 && this.hasNodes(rels)) {
+      const key = compositeId(rels);
+      const existing = Object.values(this.cells).find(c => compositeId(c.rels) === key);
       if (existing) {
         return existing;
       }
 
-      const cell = new Cell(data?.id ?? uuidv4(), rels, data);
-      this.cells[cell.id] = cell;
-      return cell;
+      if (this.joinNodes(rels)) {
+        const cell = new Cell(data?.id ?? uuidv4(), rels, data);
+        this.cells[cell.id] = cell;
+        return cell;
+      }
     }
     return null;
   }
@@ -211,6 +217,12 @@ export class Grid {
     });
 
     return changed;
+  }
+
+  // Gets an array of cells that contain the specified edge segment:
+  cellsWithEdge(n1: Node, n2: Node): Array<Cell> {
+    const edgeId = compositeId([n1.id, n2.id]);
+    return Object.values(this.cells).filter(cell => !!cell.edges[edgeId]);
   }
 
   // Finds the lowest cost path between two nodes among the grid of nodes.
@@ -387,29 +399,5 @@ export class Grid {
 
       return acc;
     }, []);
-  }
-
-  // Finds all adjacent line segments shared by two polygons.
-  // @param p1  First polygon to compare.
-  // @param p2  Second polygon to compare.
-  // @returns  Array of line segments.
-  getAdjacentCellSegments(c1: string, c2: string): Array<{ a: Node, b: Node }> {
-    const result: Array<{ a: Node, b: Node }> = [];
-    const ring1 = this.getCell(c1).rels.map(id => this.getNode(id));
-    const ring2 = this.getCell(c2).rels.map(id => this.getNode(id));
-
-    ring1.forEach((a, i) => {
-      const b = ring1[(i+1) % ring1.length];
-
-      ring2.forEach((c, j) => {
-        const d = ring2[(j+1) % ring2.length];
-
-        if (isSameLineSegment(a, b, c, d)) {
-          result.push({ a, b });
-        }
-      });
-    });
-
-    return result;
   }
 }

--- a/src/gridCell.ts
+++ b/src/gridCell.ts
@@ -1,15 +1,25 @@
+import { compositeId } from './utils';
+
 export class Cell {
   public id: string;
   public rels: Array<string>;
+  public edges: Record<string, boolean>;
   public data?: Record<any, any>;
 
   constructor(id: string, rels: Array<string>, data?: Record<any, any>) {
     this.id = id;
-    this.rels = rels.slice();
     this.data = data;
-    if (rels.length < 3) {
-      throw new Error('A cell requires a minimum of three node references');
+
+    if (rels.length !== 3) {
+      throw new Error('A cell requires exactly three node references');
     }
+
+    this.rels = rels.slice();
+    this.edges = rels.reduce((acc, a, i) => {
+      const b = rels[(i+1) % rels.length];
+      acc[compositeId([a, b])] = true;
+      return acc;
+    }, Object.create(null));
   }
 
   toConfig() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export * from './extendedGrid';
 export * from './grid';
 export * from './gridNode';
 export * from './gridCell';

--- a/src/point.ts
+++ b/src/point.ts
@@ -1,10 +1,15 @@
 export class Point {
 
-  // Tests the distance between two points.
+  // Find the distance between two points.
   public static distance(a: Point, b: Point): number {
+    return Math.sqrt(Point.distance2(a, b));
+  }
+
+  // A cheaper version of distance squared, for heuristics
+  public static distance2(a: Point, b: Point): number {
     const x: number = b.x-a.x;
     const y: number = b.y-a.y;
-    return Math.sqrt(x*x + y*y);
+    return x * x + y * y;
   }
 
   public x: number;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,10 @@ export function uuidv4() {
   });
 }
 
+export function compositeId(ids: Array<string>): string {
+  return ids.slice().sort().join('/');
+}
+
 // Tests for counter-clockwise winding among three points.
 // @param x: Point X of triangle XYZ.
 // @param y: Point Y of triangle XYZ.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -56,7 +56,7 @@ export function radiansToDegrees(radians: number): number {
 // @param b: Point B of line AB.
 // @return angle (in radians).
 export function angleRadians(a: Point, b: Point): number {
-  return Math.atan2(b.y-a.y, b.x-a.x);
+  return Math.atan2(b.y - a.y, b.x - a.x);
 }
 
 // Calculates the angle (in degrees) between line segment AB and the positive X-origin.
@@ -76,9 +76,8 @@ export function angleDegrees(a: Point, b: Point): number {
 // @param sectors: number of sectors to divide the circle into. Default is 8.
 // @param offset: offsets the origin of the sector divides within the circle. Default is PI*2/16.
 // @return sector index (a number between 0 and X-1, where X is number of sectors).
-export function angleSector(radians: number, sectors: number, offset: number): number {
+export function angleSector(radians: number, sectors: number = 8, offset?: number): number {
   const circ = Math.PI * 2;
-  sectors = sectors || 8;
   offset = offset || circ / (sectors * 2);
 
   if (radians < 0) {
@@ -98,6 +97,10 @@ export function angleSector(radians: number, sectors: number, offset: number): n
 // @param points: The ring of points to measure bounding on.
 // @return: a new Rect object of the ring's maximum extent.
 export function boundingRectForPoints(points: Array<Point>): Rect {
+  if (!points.length) {
+    return new Rect(0, 0, 0, 0);
+  }
+
   let minX = points[0].x;
   let maxX = points[0].x;
   let minY = points[0].y;
@@ -140,13 +143,13 @@ export function hitTestPointRing(p: Point, points: Array<Point>): boolean {
 // @param b: Point B of line segment AB.
 // @return: new Point object with snapped coordinates.
 export function snapPointToLineSegment(p: Point, a: Point, b: Point): Point {
-  const ap1: number = p.x-a.x;
-  const ap2: number = p.y-a.y;
-  const ab1: number = b.x-a.x;
-  const ab2: number = b.y-a.y;
-  const mag: number = ab1*ab1 + ab2*ab2;
-  const dot: number = ap1*ab1 + ap2*ab2;
-  const t: number = dot/mag;
+  const ap1: number = p.x - a.x;
+  const ap2: number = p.y - a.y;
+  const ab1: number = b.x - a.x;
+  const ab2: number = b.y - a.y;
+  const mag: number = ab1 * ab1 + ab2 * ab2;
+  const dot: number = ap1 * ab1 + ap2 * ab2;
+  const t: number = dot / mag;
 
   if (t < 0) {
     return new Point(a.x, a.y);
@@ -170,7 +173,7 @@ export function nearestPointToPoint(p: Point, points: Array<Point>): Point | nul
   for (let i = points.length-1; i >= 0; i -= 1) {
     const a = points[i];
     if (Math.abs(p.x-a.x) < bestDist) {
-      const dist = Point.distance(p, a);
+      const dist = Point.distance2(p, a);
       if (dist < bestDist) {
         bestPt = a;
         bestDist = dist;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,15 +12,19 @@ export function compositeId(ids: Array<string>): string {
   return ids.slice().sort().join('/');
 }
 
+// Test if point Z is left|on|right of an infinite 2D line.
+// > 0 left, = 0 on, < 0 right
+export function cross(x: Point, y: Point, z: Point): number {
+  return (y.x - x.x) * (z.y - x.y) - (z.x - x.x) * (y.y - x.y);
+}
+
 // Tests for counter-clockwise winding among three points.
 // @param x: Point X of triangle XYZ.
 // @param y: Point Y of triangle XYZ.
 // @param z: Point Z of triangle XYZ.
 // @param exclusive boolean: when true, equal points will be excluded from the test.
-export function ccw(x: Point, y: Point, z: Point, exclusive: boolean=false): boolean {
-  return exclusive ?
-    (z.y-x.y) * (y.x-x.x) > (y.y-x.y) * (z.x-x.x) :
-    (z.y-x.y) * (y.x-x.x) >= (y.y-x.y) * (z.x-x.x);
+export function ccw(x: Point, y: Point, z: Point): boolean {
+  return cross(x, y, z) < 0;
 }
 
 // Tests for intersection between line segments AB and CD.
@@ -126,7 +130,23 @@ export function hitTestPointRing(p: Point, points: Array<Point>): boolean {
 
   // Return true if an odd number of hits were found.
   return hits % 2 > 0;
-};
+}
+
+// export function hitTestPointRing(p: Point, points: Array<Point>): boolean {
+//   let wn = 0; // winding number
+
+//   points.forEach((a, i) => {
+//     const b = points[(i+1) % points.length];
+//     if (a.y <= p.y && b.y > p.y && cross(a, b, p) > 0) {
+//       wn += 1;
+//     } else if (b.y <= p.y && cross(a, b, p) < 0) {
+//       wn -= 1;
+//     }
+//   });
+
+//   console.log(wn)
+//   return wn !== 0;
+// }
 
 // Snaps point P to the nearest position along line segment AB.
 // @param p: Point P to snap to line segment AB.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -118,35 +118,21 @@ export function boundingRectForPoints(points: Array<Point>): Rect {
 // @param points: An array of points forming a polygonal shape.
 // @return: true if point falls within point ring.
 export function hitTestPointRing(p: Point, points: Array<Point>): boolean {
-  const origin: Point = new Point(0, p.y);
-  let hits: number = 0;
+  let wn = 0; // winding number
 
-  // Test intersection of an external ray against each polygon side.
-  points.forEach((s1, i) => {
-    const s2 = points[(i+1) % points.length];
-    origin.x = Math.min(origin.x, Math.min(s1.x, s2.x)-1);
-    hits += (intersect(origin, p, s1, s2) ? 1 : 0);
+  points.forEach((a, i) => {
+    const b = points[(i+1) % points.length];
+    if (a.y <= p.y) {
+      if (b.y > p.y && cross(a, b, p) > 0) {
+        wn += 1;
+      }
+    } else if (b.y <= p.y && cross(a, b, p) < 0) {
+      wn -= 1;
+    }
   });
 
-  // Return true if an odd number of hits were found.
-  return hits % 2 > 0;
+  return wn !== 0;
 }
-
-// export function hitTestPointRing(p: Point, points: Array<Point>): boolean {
-//   let wn = 0; // winding number
-
-//   points.forEach((a, i) => {
-//     const b = points[(i+1) % points.length];
-//     if (a.y <= p.y && b.y > p.y && cross(a, b, p) > 0) {
-//       wn += 1;
-//     } else if (b.y <= p.y && cross(a, b, p) < 0) {
-//       wn -= 1;
-//     }
-//   });
-
-//   console.log(wn)
-//   return wn !== 0;
-// }
 
 // Snaps point P to the nearest position along line segment AB.
 // @param p: Point P to snap to line segment AB.

--- a/test/extendedGrid.test.ts
+++ b/test/extendedGrid.test.ts
@@ -40,10 +40,6 @@ describe('ExtendedGrid', () => {
     return received.every((p, i) => expected[i] && p.x === expected[i].x && p.y === expected[i].y);
   }
 
-  // function numConnections(id) {
-  //   return Object.keys(grid.getNode(id).to).length;
-  // }
-
   it('should directly conntect two points within a common cell', () => {
     const s = new Point(1, 9);
     const g = new Point(5, 9);
@@ -53,117 +49,28 @@ describe('ExtendedGrid', () => {
   it('snaps a start point to the grid, then routes to nearest confined end point', () => {
     const s = new Point(-1, 5);
     const g = new Point(11, 9);
-    expect(equalPoints(exgrid.route(s, g), [s, new Point(0, 5), c, new Point(10, 9)])).toEqual(true);
+    const route = [s, new Point(0, 5), c, new Point(10, 9)];
+    expect(equalPoints(exgrid.route(s, g), route)).toEqual(true);
   });
 
   it('snaps a start point to the grid, then routes to an unconfined end point', () => {
     const s = new Point(-1, 5);
     const g = new Point(11, 9);
-    expect(equalPoints(exgrid.route(s, g, false), [s, new Point(0, 5), c, new Point(10, 9), g])).toEqual(true);
+    const route = [s, new Point(0, 5), c, new Point(10, 9), g];
+    expect(equalPoints(exgrid.route(s, g, false), route)).toEqual(true);
   });
 
-  // it('should directly connect two points in adjacent polygons who\'s ray intersects their common side.', () => {
-  //   // Connect two points within the same polygon:
-  //   const start = { x: 26, y: 26 };
-  //   const goal = { x: 74, y: 74 };
-  //   const path = grid.bridgePoints(start, goal);
+  it('snaps a start point to the grid, then directly routes to a point in a related cell', () => {
+    const s = new Point(-1, 5);
+    const g = new Point(1, 5);
+    const route = [s, new Point(0, 5), g];
+    expect(equalPoints(exgrid.route(s, g), route)).toEqual(true);
+  });
 
-  //   // Expect direct connection (start >> goal).
-  //   expect(path.length).toEqual(2);
-  //   expect(path[0]).toEqual(start);
-  //   expect(path[1]).toEqual(goal);
-  // });
-
-  // it('should snap a point to a grid segment, then directly connect it to a point within a related cell.')
-
-  // it('should snap points to a grid segment, then directly connect them through a common polygon.', () => {
-  //   const start = { x: 20, y: 50 };
-  //   const goal = { x: 50, y: 20 };
-  //   const path = grid.bridgePoints(start, goal);
-
-  //   expect(path.length).toEqual(4);
-  //   expect(path[0]).toEqual(start);
-  //   expect(path[1]).toEqual({ x: 25, y: 50 });
-  //   expect(path[2]).toEqual({ x: 50, y: 25 });
-  //   expect(path[3]).toEqual(goal);
-  // });
-
-  // it('should snap points to a grid segment, then directly connect them along a common line segment.', () => {
-  //   const start = { x: 100, y: 20 };
-  //   const goal = { x: 110, y: 20 };
-  //   const path = grid.bridgePoints(start, goal);
-
-  //   expect(path.length).toEqual(4);
-  //   expect(path[0]).toEqual(start);
-  //   expect(path[1]).toEqual({ x: 100, y: 25 });
-  //   expect(path[2]).toEqual({ x: 110, y: 25 });
-  //   expect(path[3]).toEqual(goal);
-  // });
-
-  // it.only('should connect two points by following only the grid when no polygons are available.', () => {
-  //   const start = { x: 120, y: 20 };
-  //   const goal = { x: 120, y: 50 };
-  //   const path = grid.bridgePoints(start, goal);
-
-  //   expect(path.length).toEqual(5);
-  //   expect(path[0]).toEqual(start);
-  //   expect(path[1]).toEqual({ x: 120, y: 25 });
-  //   expect(path[2]).toEqual({ x: 125, y: 25 });
-  //   // expect(path[3]).toEqual(some other point along the segment...);
-  //   expect(path[4]).toEqual(goal);
-  // });
-
-  // it.only('should connect two points by following the grid using polygons, when available.', () => {
-  //   const start = { x: 20, y: 70 };
-  //   const goal = { x: 100, y: 20 };
-  //   const path = grid.bridgePoints(start, goal);
-
-  //   expect(path.length).toEqual(5);
-  //   expect(path[0]).toEqual(start);
-  //   expect(path[1]).toEqual({ x: 25, y: 70 });
-  //   expect(path[2]).toEqual({ x: 75, y: 25 });
-  //   expect(path[3]).toEqual({ x: 100, y: 25 });
-  //   expect(path[4]).toEqual(goal);
-  // });
-
-  // it('should exclude start point when already at a valid grid location.', () => {
-  //   const start = { x: 25, y: 50 };
-  //   const goal = { x: 26, y: 26 };
-  //   const path = grid.bridgePoints(start, goal);
-
-  //   expect(path.length).toEqual(2);
-  //   expect(path[0]).toEqual({ x: 25, y: 50 });
-  //   expect(path[1]).toEqual({ x: 26, y: 26 });
-  // });
-
-  // it('should exclude out-of-grid goal node when confined to the grid.', () => {
-  //   const start = { x: 100, y: 20 };
-  //   const goal = { x: 110, y: 20 };
-  //   const path = grid.bridgePoints(start, goal, true);
-
-  //   expect(path.length).toEqual(3);
-  //   expect(path[0]).toEqual(start);
-  //   expect(path[1]).toEqual({ x: 100, y: 25 });
-  //   expect(path[2]).toEqual({ x: 110, y: 25 });
-  // });
-
-  // it.skip('bridgePoints: should connect two points via the grid using snapped-point bridge.', () => {
-  //   var a = grid.addNode(0, 0).id;
-  //   var b = grid.addNode(100, 100).id;
-  //   var c = grid.addNode(200, 100).id;
-  //   var d = grid.addNode(300, 0).id;
-  //   grid.joinNodes(a, b);
-  //   grid.joinNodes(b, c);
-  //   grid.joinNodes(c, d);
-
-  //   const path = grid.bridgePoints({ x: 50, y: 40 }, { x: 240, y: 40 });
-
-  //   // Test that we got a path back:
-  //   expect(path.length).toEqual(6);
-
-  //   // Test that the grid has been cleaned up:
-  //   expect(grid.getNumNodes()).toEqual(4);
-  // });
-
-  // it('bridgePoints: should eliminate redundant points in returned path.');
+  it('snaps start and end points to the grid, then directly routes points on the same segment', () => {
+    const s = new Point(2, -1);
+    const g = new Point(8, -1);
+    const route = [s, new Point(2, 0), new Point(8, 0), g];
+    expect(equalPoints(exgrid.route(s, g), route)).toEqual(true);
+  });
 });

--- a/test/extendedGrid.test.ts
+++ b/test/extendedGrid.test.ts
@@ -1,0 +1,141 @@
+import { ExtendedGrid } from '../src/extendedGrid';
+import { Grid } from '../src/grid';
+import { Point } from '../src/point';
+
+describe('ExtendedGrid', () => {
+  let grid: Grid;
+  let exgrid: ExtendedGrid;
+
+  beforeEach(() => {
+    grid = new Grid();
+    exgrid = new ExtendedGrid(grid);
+    const a = grid.addNode(25, 25).id;
+    const b = grid.addNode(75, 25).id;
+    const c = grid.addNode(25, 75).id;
+    const d = grid.addNode(75, 75).id;
+    const e = grid.addNode(125, 25).id;
+
+    grid.addCell([a, b, c]);
+    grid.addCell([b, c, d]);
+    grid.joinNodes([b, d, e]);
+  });
+
+  // function numConnections(id) {
+  //   return Object.keys(grid.getNode(id).to).length;
+  // }
+
+  it('should directly conntect two points within a common polygon.', () => {
+    const s = new Point(26, 26);
+    const g = new Point(28, 28);
+    expect(exgrid.route(s, g)).toEqual([s, g]);
+  });
+
+  // it('should directly connect two points in adjacent polygons who\'s ray intersects their common side.', () => {
+  //   // Connect two points within the same polygon:
+  //   const start = { x: 26, y: 26 };
+  //   const goal = { x: 74, y: 74 };
+  //   const path = grid.bridgePoints(start, goal);
+
+  //   // Expect direct connection (start >> goal).
+  //   expect(path.length).toEqual(2);
+  //   expect(path[0]).toEqual(start);
+  //   expect(path[1]).toEqual(goal);
+  // });
+
+  it('should snap a point to a grid segment, then directly connect it to a point within a related cell.', () => {
+    const s = new Point(20, 50);
+    const g = new Point(26, 26);
+    expect(exgrid.route(s, g)).toEqual([s, new Point(25, 50), g]);
+  });
+
+  // it('should snap points to a grid segment, then directly connect them through a common polygon.', () => {
+  //   const start = { x: 20, y: 50 };
+  //   const goal = { x: 50, y: 20 };
+  //   const path = grid.bridgePoints(start, goal);
+
+  //   expect(path.length).toEqual(4);
+  //   expect(path[0]).toEqual(start);
+  //   expect(path[1]).toEqual({ x: 25, y: 50 });
+  //   expect(path[2]).toEqual({ x: 50, y: 25 });
+  //   expect(path[3]).toEqual(goal);
+  // });
+
+  // it('should snap points to a grid segment, then directly connect them along a common line segment.', () => {
+  //   const start = { x: 100, y: 20 };
+  //   const goal = { x: 110, y: 20 };
+  //   const path = grid.bridgePoints(start, goal);
+
+  //   expect(path.length).toEqual(4);
+  //   expect(path[0]).toEqual(start);
+  //   expect(path[1]).toEqual({ x: 100, y: 25 });
+  //   expect(path[2]).toEqual({ x: 110, y: 25 });
+  //   expect(path[3]).toEqual(goal);
+  // });
+
+  // it.only('should connect two points by following only the grid when no polygons are available.', () => {
+  //   const start = { x: 120, y: 20 };
+  //   const goal = { x: 120, y: 50 };
+  //   const path = grid.bridgePoints(start, goal);
+
+  //   expect(path.length).toEqual(5);
+  //   expect(path[0]).toEqual(start);
+  //   expect(path[1]).toEqual({ x: 120, y: 25 });
+  //   expect(path[2]).toEqual({ x: 125, y: 25 });
+  //   // expect(path[3]).toEqual(some other point along the segment...);
+  //   expect(path[4]).toEqual(goal);
+  // });
+
+  // it.only('should connect two points by following the grid using polygons, when available.', () => {
+  //   const start = { x: 20, y: 70 };
+  //   const goal = { x: 100, y: 20 };
+  //   const path = grid.bridgePoints(start, goal);
+
+  //   expect(path.length).toEqual(5);
+  //   expect(path[0]).toEqual(start);
+  //   expect(path[1]).toEqual({ x: 25, y: 70 });
+  //   expect(path[2]).toEqual({ x: 75, y: 25 });
+  //   expect(path[3]).toEqual({ x: 100, y: 25 });
+  //   expect(path[4]).toEqual(goal);
+  // });
+
+  // it('should exclude start point when already at a valid grid location.', () => {
+  //   const start = { x: 25, y: 50 };
+  //   const goal = { x: 26, y: 26 };
+  //   const path = grid.bridgePoints(start, goal);
+
+  //   expect(path.length).toEqual(2);
+  //   expect(path[0]).toEqual({ x: 25, y: 50 });
+  //   expect(path[1]).toEqual({ x: 26, y: 26 });
+  // });
+
+  // it('should exclude out-of-grid goal node when confined to the grid.', () => {
+  //   const start = { x: 100, y: 20 };
+  //   const goal = { x: 110, y: 20 };
+  //   const path = grid.bridgePoints(start, goal, true);
+
+  //   expect(path.length).toEqual(3);
+  //   expect(path[0]).toEqual(start);
+  //   expect(path[1]).toEqual({ x: 100, y: 25 });
+  //   expect(path[2]).toEqual({ x: 110, y: 25 });
+  // });
+
+  // it.skip('bridgePoints: should connect two points via the grid using snapped-point bridge.', () => {
+  //   var a = grid.addNode(0, 0).id;
+  //   var b = grid.addNode(100, 100).id;
+  //   var c = grid.addNode(200, 100).id;
+  //   var d = grid.addNode(300, 0).id;
+  //   grid.joinNodes(a, b);
+  //   grid.joinNodes(b, c);
+  //   grid.joinNodes(c, d);
+
+  //   const path = grid.bridgePoints({ x: 50, y: 40 }, { x: 240, y: 40 });
+
+  //   // Test that we got a path back:
+  //   expect(path.length).toEqual(6);
+
+  //   // Test that the grid has been cleaned up:
+  //   expect(grid.getNumNodes()).toEqual(4);
+  // });
+
+  // it('bridgePoints: should eliminate redundant points in returned path.');
+});

--- a/test/grid.test.ts
+++ b/test/grid.test.ts
@@ -203,11 +203,21 @@ describe('Grid', () => {
   });
 
   describe('addCell', () => {
-    it('creates a cell from a group of nodes, and returns it', () => {
-      const a = grid.addNode().id;
-      const b = grid.addNode().id;
-      const c = grid.addNode().id;
+    it('creates a cell from a ccw group of nodes, and returns it', () => {
+      const a = grid.addNode(0, 0).id;
+      const b = grid.addNode(0, 10).id;
+      const c = grid.addNode(10, 10).id;
       const x = grid.addCell([a, b, c]) as Cell;
+
+      expect(grid.cellCount).toEqual(1);
+      expect(x.rels).toEqual([a, b, c]);
+    });
+
+    it('creates a normalized (ccw) cell from a cw group of nodes, and returns it', () => {
+      const a = grid.addNode(0, 0).id;
+      const b = grid.addNode(0, 10).id;
+      const c = grid.addNode(10, 10).id;
+      const x = grid.addCell([c, b, a]) as Cell;
 
       expect(grid.cellCount).toEqual(1);
       expect(x.rels).toEqual([a, b, c]);
@@ -481,15 +491,17 @@ describe('Grid', () => {
       const b = grid.addNode(100, 0).id;
       const c = grid.addNode(0, 100).id;
       const d = grid.addNode(100, 100).id;
-      grid.addCell([a, b, c]);
-      grid.addCell([a, c, d]);
+      grid.addCell([a, b, c]); // cw
+      grid.addCell([a, c, d]); // ccw
       const hit1 = grid.cellsContainingPoint({ x: 5, y: 50 });
       const hit2 = grid.cellsContainingPoint({ x: 50, y: 5 });
-      const hit3 = grid.cellsContainingPoint({ x: 95, y: 50 });
+      const hit3 = grid.cellsContainingPoint({ x: 50, y: 95 });
+      const hit4 = grid.cellsContainingPoint({ x: 95, y: 50 });
 
       expect(hit1.length).toEqual(2);
       expect(hit2.length).toEqual(1);
-      expect(hit3.length).toEqual(0);
+      expect(hit3.length).toEqual(1);
+      expect(hit4.length).toEqual(0);
     });
 
     it('returns empty when there are no cells', () => {

--- a/test/grid.test.ts
+++ b/test/grid.test.ts
@@ -15,7 +15,7 @@ describe('Grid', () => {
     return Object.keys(node.to).length;
   }
 
-  const sortNodes: (a: Node, b: Node) => number = (a, b) => a.id.localeCompare(b.id);
+  const sortElements: (a: Node | Cell, b: Node | Cell) => number = (a, b) => a.id.localeCompare(b.id);
 
   describe('addNode', () => {
     it('adds a new node with specified X and Y coordinates, and returns it', () => {
@@ -498,29 +498,15 @@ describe('Grid', () => {
   });
 
   describe('nodesInCell', () => {
-    it("returns an array of all node ids contained within a polygon", () => {
-      const a = grid.addNode(0, 0);
-      const b = grid.addNode(100, 0);
-      const c = grid.addNode(0, 100);
-      const d = grid.addNode(50, 25); // Inside figure ABC
-      grid.addNode(200, 200); // Outside figure ABC
-      const order: (a: Node, b: Node) => number = (a, b) => a.id.localeCompare(b.id);
-      const cell = grid.addCell([a, b, c].map(n => n.id)) as Cell;
-      const nodes = grid.nodesInCell(cell.id).sort(order);
-      expect(nodes).toEqual([a, b, c, d].sort(order));
-    });
-  });
-
-  describe('nodesInCell', () => {
-    it("returns an array of all node ids contained within a polygon", () => {
+    it("returns an array of all node ids contained within a cell", () => {
       const a = grid.addNode(0, 0);
       const b = grid.addNode(100, 0);
       const c = grid.addNode(0, 100);
       const d = grid.addNode(50, 25); // Inside figure ABC
       grid.addNode(200, 200); // Outside figure ABC
       const cell = grid.addCell([a, b, c].map(n => n.id)) as Cell;
-      const nodes = grid.nodesInCell(cell.id).sort(sortNodes);
-      expect(nodes).toEqual([a, b, c, d].sort(sortNodes));
+      const nodes = grid.nodesInCell(cell.id).sort(sortElements);
+      expect(nodes).toEqual([a, b, c, d].sort(sortElements));
     });
   });
 
@@ -530,35 +516,19 @@ describe('Grid', () => {
       const b = grid.addNode(50, 50);
       grid.addNode(100, 100);
       const nodes = grid.nodesInRect(new Rect(75, 75, -100, -100));
-
-      expect(nodes.sort(sortNodes)).toEqual([a, b].sort(sortNodes));
+      expect(nodes.sort(sortElements)).toEqual([a, b].sort(sortElements));
     });
   });
 
-  describe('getAdjacentCellSegments', () => {
-    it("returns an array specifying an adjacent line segment", () => {
+   describe('cellsWithEdge', () => {
+    it("returns an array of all cells containing an edge", () => {
       const a = grid.addNode(0, 0);
       const b = grid.addNode(100, 0);
       const c = grid.addNode(0, 100);
       const d = grid.addNode(100, 100);
-      const c1 = grid.addCell([a, b, c].map(n => n.id)) as Cell;
-      const c2 = grid.addCell([a, c, d].map(n => n.id)) as Cell;
-
-      expect(grid.getAdjacentCellSegments(c1.id, c2.id)).toEqual([{ a: c, b: a }]);
-    });
-
-    it("finds all adjacent line segments in interlocking polygons", () => {
-      const a = grid.addNode(0, 0);
-      const b = grid.addNode(50, 50);
-      const c = grid.addNode(0, 100);
-      const d = grid.addNode(100, 50);
-      const c1 = grid.addCell([a, b, c].map(n => n.id)) as Cell;
-      const c2 = grid.addCell([a, d, c, b].map(n => n.id)) as Cell;
-
-      expect(grid.getAdjacentCellSegments(c1.id, c2.id)).toEqual([
-        { a: a, b: b },
-        { a: b, b: c },
-      ]);
+      const cell1 = grid.addCell([a, b, c].map(n => n.id)) as Cell;
+      const cell2 = grid.addCell([a, c, d].map(n => n.id)) as Cell;
+      expect(grid.cellsWithEdge(a, c).sort(sortElements)).toEqual([cell1, cell2].sort(sortElements));
     });
   });
 });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,10 +1,21 @@
 import { Point } from '../src/point';
-import { cross, ccw } from '../src/utils';
+import { Rect } from '../src/rect';
+import {
+  cross,
+  ccw,
+  intersect,
+  angleDegrees,
+  boundingRectForPoints,
+  hitTestPointRing,
+} from '../src/utils';
 
 describe('cross', () => {
+  // A - -
+  // - - -
+  // B - C
   const a: Point = new Point(0, 0);
-  const b: Point = new Point(0, 10);
-  const c: Point = new Point(10, 10);
+  const b: Point = new Point(0, 2);
+  const c: Point = new Point(2, 2);
 
   it('returns negative for counter-clockwise winding', () => {
     expect(cross(a, b, c)).toBeLessThan(0);
@@ -24,9 +35,12 @@ describe('cross', () => {
 });
 
 describe('ccw', () => {
+  // A - -
+  // - - -
+  // B - C
   const a: Point = new Point(0, 0);
-  const b: Point = new Point(0, 10);
-  const c: Point = new Point(10, 10);
+  const b: Point = new Point(0, 2);
+  const c: Point = new Point(2, 2);
 
   it('returns true for counter-clockwise winding', () => {
     expect(ccw(a, b, c)).toEqual(true);
@@ -38,5 +52,84 @@ describe('ccw', () => {
 
   it('returns zero for straight alignment', () => {
     expect(ccw(a, b, a)).toEqual(false);
+  });
+});
+
+describe('intersect', () => {
+  // A - - D
+  // - E - -
+  // - - - -
+  // B - - C
+  const a: Point = new Point(0, 0);
+  const b: Point = new Point(0, 3);
+  const c: Point = new Point(3, 3);
+  const d: Point = new Point(3, 0);
+  const e: Point = new Point(1, 1);
+
+  it('returns true for intersecting lines', () => {
+    expect(intersect(a, c, b, d)).toEqual(true);
+    expect(intersect(c, a, b, d)).toEqual(true);
+    expect(intersect(c, a, d, b)).toEqual(true);
+  });
+
+  it('returns false for parallel lines', () => {
+    expect(intersect(a, b, c, d)).toEqual(false);
+    expect(intersect(b, a, c, d)).toEqual(false);
+    expect(intersect(b, a, d, c)).toEqual(false);
+    expect(intersect(a, d, b, c)).toEqual(false);
+    expect(intersect(a, e, b, d)).toEqual(false);
+  });
+});
+
+describe('angleDegrees', () => {
+  it('returns degrees from positive x-origin', () => {
+    expect(angleDegrees(new Point(5, 5), new Point(10, 10))).toEqual(45);
+    expect(angleDegrees(new Point(-5, 5), new Point(-10, 10))).toEqual(135);
+    expect(angleDegrees(new Point(-5, -5), new Point(-10, -10))).toEqual(225);
+    expect(angleDegrees(new Point(5, -5), new Point(10, -10))).toEqual(315);
+  });
+});
+
+describe('boundingRectForPoints', () => {
+  // - - D -
+  // A - - -
+  // - - - C
+  // - B - -
+  const a: Point = new Point(0, 1);
+  const b: Point = new Point(1, 3);
+  const c: Point = new Point(3, 2);
+  const d: Point = new Point(2, 0);
+
+  it('returns the bounding box of a collection of points', () => {
+    expect(boundingRectForPoints([a, b, c, d])).toEqual(new Rect(0, 0, 3, 3));
+  });
+
+  it('works with a single point', () => {
+    expect(boundingRectForPoints([a])).toEqual(new Rect(0, 1, 0, 0));
+  });
+
+  it('returns zero origin for no points given', () => {
+    expect(boundingRectForPoints([])).toEqual(new Rect(0, 0, 0, 0));
+  });
+});
+
+describe('hitTestPointRing', () => {
+  // - - D -
+  // A - - -
+  // - - - C
+  // - B - -
+  const a: Point = new Point(0, 1);
+  const b: Point = new Point(1, 3);
+  const c: Point = new Point(3, 2);
+  const d: Point = new Point(2, 0);
+
+  it('tests point in counter-clockwise winding', () => {
+    expect(hitTestPointRing(new Point(1, 2), [a, b, c, d])).toEqual(true);
+    expect(hitTestPointRing(new Point(0, 0), [a, b, c, d])).toEqual(false);
+  });
+
+  it('tests point in clockwise winding', () => {
+    expect(hitTestPointRing(new Point(1, 2), [d, c, b, a])).toEqual(true);
+    expect(hitTestPointRing(new Point(0, 0), [d, c, b, a])).toEqual(false);
   });
 });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,42 @@
+import { Point } from '../src/point';
+import { cross, ccw } from '../src/utils';
+
+describe('cross', () => {
+  const a: Point = new Point(0, 0);
+  const b: Point = new Point(0, 10);
+  const c: Point = new Point(10, 10);
+
+  it('returns negative for counter-clockwise winding', () => {
+    expect(cross(a, b, c)).toBeLessThan(0);
+    expect(cross(b, c, a)).toBeLessThan(0);
+    expect(cross(c, a, b)).toBeLessThan(0);
+  });
+
+  it('returns positive for clockwise winding', () => {
+    expect(cross(c, b, a)).toBeGreaterThan(0);
+    expect(cross(b, a, c)).toBeGreaterThan(0);
+    expect(cross(a, c, b)).toBeGreaterThan(0);
+  });
+
+  it('returns zero for straight alignment', () => {
+    expect(cross(a, b, a)).toEqual(0);
+  });
+});
+
+describe('ccw', () => {
+  const a: Point = new Point(0, 0);
+  const b: Point = new Point(0, 10);
+  const c: Point = new Point(10, 10);
+
+  it('returns true for counter-clockwise winding', () => {
+    expect(ccw(a, b, c)).toEqual(true);
+  });
+
+  it('returns false for clockwise winding', () => {
+    expect(ccw(a, c, b)).toEqual(false);
+  });
+
+  it('returns zero for straight alignment', () => {
+    expect(ccw(a, b, a)).toEqual(false);
+  });
+});

--- a/website/app.js
+++ b/website/app.js
@@ -1,5 +1,5 @@
 const shiftClickHint = 'SHIFT+click adds to selection';
-const getLineId = (n1, n2) => [n1.id, n2.id].sort().join('-');
+const getLineId = (n1, n2) => Constellation.compositeId([n1.id, n2.id]);
 const App = {
   data() {
     return {
@@ -107,11 +107,11 @@ const App = {
     },
 
     addCell() {
-      if (this.nodeSelection && this.selections.length >= 3) {
+      if (this.nodeSelection && this.selections.length === 3) {
         this.grid.addCell(Object.keys(this.selectionIds));
         this.save();
       } else {
-        this.alert('Select three or more nodes', { hint: shiftClickHint });
+        this.alert('Select exactly three nodes', { hint: shiftClickHint });
       }
     },
 


### PR DESCRIPTION
Adds `ExtendedGrid` (replaces old `bridgePoints`), limits cells to three nodes, upgrades polygon hit tests to use winding number, other odds and ends.